### PR TITLE
fix: usar API de WooCommerce en lugar de get_post_meta (compatibilidad HPOS)

### DIFF
--- a/woo-ifactura/ifactura/ConectoriFactura.class.php
+++ b/woo-ifactura/ifactura/ConectoriFactura.class.php
@@ -961,37 +961,33 @@ class ConectoriFactura
     {
         global $woocommerce;
         $ordenExtendida = new WCOrdenExtendida($order_id);
-        $order_meta = get_post_meta($order_id);
-        $billing_currency = $order_meta["_order_currency"][0];
-        $billing_first_name = $order_meta["_billing_first_name"][0];
-        $billing_last_name = $order_meta["_billing_last_name"][0];
-        $billing_email = $order_meta["_billing_email"][0];
-        $billing_postcode = $order_meta["_billing_postcode"][0];
-        $payment_method = $order_meta["_payment_method"][0];
-        $billing_address_1 = $order_meta["_billing_address_1"][0];
-        $billing_address_2 = "";
-        //PORQUE PUEDE ESTAR VACIO O NULO
-        if (key_exists("_billing_address_2",$order_meta))
-        {
-            $billing_address_2 = $order_meta["_billing_address_2"][0];
-        }        
-        $billing_city = $order_meta["_billing_city"][0];
-        $billing_phone = $order_meta["_billing_phone"][0];
-        $billing_company = $order_meta["_billing_company"][0];
+        $order = wc_get_order($order_id);
+        $billing_currency   = $order->get_currency();
+        $billing_first_name = $order->get_billing_first_name();
+        $billing_last_name  = $order->get_billing_last_name();
+        $billing_email      = $order->get_billing_email();
+        $billing_postcode   = $order->get_billing_postcode();
+        $payment_method     = $order->get_payment_method();
+        $billing_address_1  = $order->get_billing_address_1();
+        $billing_address_2  = $order->get_billing_address_2();
+        $billing_city       = $order->get_billing_city();
+        $billing_phone      = $order->get_billing_phone();
+        $billing_company    = $order->get_billing_company();
+        $customer_user      = $order->get_customer_id();
         if (class_exists("WC_Countries")) {
             /* WC > 2.3.0 */
             $countries = new WC_Countries();
             $states = $countries->get_states("AR");
-            $billing_state = $states[$order_meta["_billing_state"][0]]; // SOLO ARGENTINA
+            $billing_state = $states[$order->get_billing_state()]; // SOLO ARGENTINA
         } else {
             global $states;
-            $billing_state = $states["AR"][$order_meta["_billing_state"][0]]; // SOLO ARGENTINA
+            $billing_state = $states["AR"][$order->get_billing_state()]; // SOLO ARGENTINA
         }
-        $customer_user = $order_meta["_customer_user"][0];
         /*Patch for DOS61*/
-        if (isset($order_meta['_billing_street'])) {
-            $billing_address_1 = $order_meta['_billing_street'][0].' '.$order_meta['_billing_number'][0];
-            $billing_address_2 = $order_meta['_billing_floor'][0].' '.$order_meta['_billing_apartment'][0];
+        $billing_street = $order->get_meta('_billing_street');
+        if (!empty($billing_street)) {
+            $billing_address_1 = $billing_street . ' ' . $order->get_meta('_billing_number');
+            $billing_address_2 = $order->get_meta('_billing_floor') . ' ' . $order->get_meta('_billing_apartment');
         }
         $cliente = new ClienteiFactura();
         $razonsoc = $billing_first_name .  " " . $billing_last_name;

--- a/woo-ifactura/includes/class-woo-ifactura.php
+++ b/woo-ifactura/includes/class-woo-ifactura.php
@@ -64,7 +64,7 @@ class Woo_iFactura
     {
         $this->plugin_name = 'iFactura para WooCommerce';
         
-        $this->version = '2.0';
+        $this->version = '2.0.1';
 
         $this->load_dependencies();
         

--- a/woo-ifactura/woo-ifactura.php
+++ b/woo-ifactura/woo-ifactura.php
@@ -3,7 +3,7 @@
 /**
 * Plugin Name: Woo iFactura
 * Description: Woo iFactura integra WooCommerce con el servicio de factura electrónica de iFactura.com.ar
-* Version: 2.0
+* Version: 2.0.1
 * Author: Federico Alvarez
 * Author URI: https://github.com/fedealvz/Woo-iFactura
 * Text Domain: woo-ifactura
@@ -18,7 +18,7 @@
 * 
 * @author Federico Alvarez
 * @package woo-ifactura
-* @version 2.0
+* @version 2.0.1
 */
 
 // If this file is called directly, abort.


### PR DESCRIPTION
## Problema

Cuando **HPOS (High Performance Order Storage)** está activo en WooCommerce 8+, los pedidos se almacenan en tablas propias en lugar de `wp_postmeta`. El método `armarCliente()` usaba `get_post_meta($order_id)` para leer todos los campos de facturación, lo cual devuelve datos vacíos bajo HPOS — incluso cuando el modo de compatibilidad está activo y la sincronización no finalizó.

Esto causa que `billing_state` sea `null`, que `woo_ifactura_elegirprovincia(null)` no encuentre ningún match y retorne vacío, y que la API de iFactura responda con:

```
The Provincia field is required
```

## Solución

Reemplazar todas las llamadas a `get_post_meta()` en `armarCliente()` por la API oficial de WooCommerce (`wc_get_order()`), que funciona correctamente independientemente del backend de almacenamiento:

| Antes | Después |
|---|---|
| `get_post_meta($order_id)` | `wc_get_order($order_id)` |
| `$order_meta["_billing_state"][0]` | `$order->get_billing_state()` |
| `$order_meta["_billing_first_name"][0]` | `$order->get_billing_first_name()` |
| ... | ... |

El parche especial DOS61 para campos de calle personalizados se preserva usando `$order->get_meta()`.

## Compatibilidad

| Configuración | Antes del fix | Después del fix |
|---|---|---|
| Solo legacy (wp_postmeta) | ✅ Funciona | ✅ Funciona |
| HPOS + modo compatibilidad (sync completo) | ✅ Funciona | ✅ Funciona |
| HPOS + modo compatibilidad (sync pendiente) | ❌ Falla | ✅ Funciona |
| Solo HPOS (sin compatibilidad) | ❌ Falla | ✅ Funciona |

`wc_get_order()` siempre sabe dónde buscar los datos sin importar el backend. `get_post_meta()` solo sabe leer `wp_postmeta`.

- Sin cambios de comportamiento para instalaciones con almacenamiento legacy
- 100% compatible hacia atrás: todos los métodos usados existen desde WooCommerce 3.0+, y el plugin requiere mínimo WC 7.3.0

## Nota

El archivo `woo-ifactura.php` ya declaraba compatibilidad con HPOS (`custom_order_tables: true`), pero `armarCliente()` no había sido actualizado para usar la API correcta.