### PR TITLE
fix: comparación de versión rota en WC 10+, seguridad AJAX y limpieza

### DIFF
--- a/woo-ifactura/admin/class-woo-ifactura-admin.php
+++ b/woo-ifactura/admin/class-woo-ifactura-admin.php
@@ -85,7 +85,10 @@ class Woo_iFactura_Admin
     public function enqueue_scripts()
     {
         wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/woo-ifactura-admin.js', array( 'jquery' ), $this->version, false);
-        wp_localize_script($this->plugin_name, 'fyifacturaAdminVars', array('ifacturaUrl' => plugin_dir_url(__FILE__) ));
+        wp_localize_script($this->plugin_name, 'fyifacturaAdminVars', array(
+            'ifacturaUrl' => plugin_dir_url(__FILE__),
+            'nonce'       => wp_create_nonce('woo_ifactura_ajax_nonce'),
+        ));
     }
     
     public function add_settings_tab($settings_tabs)
@@ -804,26 +807,38 @@ class Woo_iFactura_Admin
     *
     **/    
     public function woo_ifactura_invoice()
-    {         
-        $order_id = intval($_POST["order"]);      
-        $iFactura = new ConectoriFactura();  
+    {
+        check_ajax_referer('woo_ifactura_ajax_nonce', 'nonce');
+        if (! current_user_can('manage_woocommerce')) {
+            die(json_encode(array("Exito" => false, "Mensaje" => "No tenés permisos para realizar esta acción.")));
+        }
+        $order_id = intval($_POST["order"]);
+        $iFactura = new ConectoriFactura();
         $respuesta = $iFactura->woo_ifactura_procesarInvoice($order_id);
         die(json_encode($respuesta,JSON_PRETTY_PRINT));
     }
      /**
     * Procesar la petición AJAX para generar la nota de crédito
     *
-    **/    
+    **/
     public function woo_ifactura_cancel_invoice()
-    {         
-        $order_id = intval($_POST["order"]);      
-        $iFactura = new ConectoriFactura();  
+    {
+        check_ajax_referer('woo_ifactura_ajax_nonce', 'nonce');
+        if (! current_user_can('manage_woocommerce')) {
+            die(json_encode(array("Exito" => false, "Mensaje" => "No tenés permisos para realizar esta acción.")));
+        }
+        $order_id = intval($_POST["order"]);
+        $iFactura = new ConectoriFactura();
         $respuesta = $iFactura->woo_ifactura_cancelarInvoice($order_id);
         die(json_encode($respuesta,JSON_PRETTY_PRINT));
     }
     public function woo_ifactura_view_invoice()
     {
-        $order_id = intval($_POST["order"]);        
+        check_ajax_referer('woo_ifactura_ajax_nonce', 'nonce');
+        if (! current_user_can('manage_woocommerce')) {
+            die(json_encode(array("Exito" => false, "Mensaje" => "No tenés permisos para realizar esta acción.")));
+        }
+        $order_id = intval($_POST["order"]);
         $conector = new ConectoriFactura();
         $url = $conector->getUrlInvoiceGenerada($order_id);
         try {
@@ -844,7 +859,11 @@ class Woo_iFactura_Admin
     }
     public function woo_ifactura_view_cancel_invoice()
     {
-        $order_id = intval($_POST["order"]);        
+        check_ajax_referer('woo_ifactura_ajax_nonce', 'nonce');
+        if (! current_user_can('manage_woocommerce')) {
+            die(json_encode(array("Exito" => false, "Mensaje" => "No tenés permisos para realizar esta acción.")));
+        }
+        $order_id = intval($_POST["order"]);
         $conector = new ConectoriFactura();
         $url = $conector->getUrlNotaGenerada($order_id);
         try {
@@ -865,6 +884,10 @@ class Woo_iFactura_Admin
     }
     public function woo_ifactura_view_delete_invoices()
     {
+        check_ajax_referer('woo_ifactura_ajax_nonce', 'nonce');
+        if (! current_user_can('manage_woocommerce')) {
+            die(json_encode(array("Exito" => false, "Mensaje" => "No tenés permisos para realizar esta acción.")));
+        }
         $order_id = intval($_POST["order"]);
         $ordenExtendida = new WCOrdenExtendida($order_id);
         try

--- a/woo-ifactura/admin/class-woo-ifactura-admin.php
+++ b/woo-ifactura/admin/class-woo-ifactura-admin.php
@@ -132,21 +132,24 @@ class Woo_iFactura_Admin
     }
     
     /**
-     * Gets order id in WooCommerce 3.0 and older versions
+     * Gets order id.
+     *
+     * The plugin has required WooCommerce 7.3.0+ since the "WC requires
+     * at least" header was added, so the pre-3.0 $order->id fallback this
+     * used to have was dead code - and worse, the `$woocommerce->version
+     * >= '3.0'` check that guarded it was a *string* comparison, which
+     * evaluates false for any WooCommerce version >= 10.0 (e.g. "11.0.1"
+     * >= "3.0" is false lexically), so on current WooCommerce this method
+     * was silently falling into the deprecated $order->id branch and
+     * triggering a "Order properties should not be accessed directly"
+     * doing_it_wrong notice on every call.
      *
      * @since 0.0.3
      */
-    
     public function get_order_id($order)
     {
-        global $woocommerce;        
-        if ($woocommerce->version >= '3.0') {
-            $order_id = $order->get_id();
-        } else {
-            $order_id = $order->id;
-        }        
-        return $order_id;
-    }    
+        return $order->get_id();
+    }
     /**
     * Adds DNI to register form
     *
@@ -878,6 +881,7 @@ class Woo_iFactura_Admin
     }
     public function woo_ifactura_buttons_column($columns)
     {
+        $new_columns = array();
         foreach ($columns as $column_name => $column_info) {
 
             $new_columns[$column_name] = $column_info;

--- a/woo-ifactura/admin/js/woo-ifactura-admin.js
+++ b/woo-ifactura/admin/js/woo-ifactura-admin.js
@@ -15,7 +15,8 @@
             var esto = $(this);
             var data = {
                 action: 'woo_ifactura_do_ajax_request',
-                order: order_id
+                order: order_id,
+                nonce: fyifacturaAdminVars.nonce
             }
             var awaitingButton = '<a class="button tips fy-awaiting-button" data-invoice="0" href="#"></a> Generando...';
             var botonAnterior = td.html();
@@ -69,7 +70,8 @@
             var esto = $(this);
             var data = {
                 action: 'woo_ifactura_do_cancel_ajax_request',
-                order: order_id
+                order: order_id,
+                nonce: fyifacturaAdminVars.nonce
             }
             var awaitingButton = '<a class="button tips fy-awaiting-button" data-invoice="0" href="#">Esperando generación</a> Nota de crédito';
             td.html(awaitingButton);
@@ -120,7 +122,8 @@ function viewInvoice() {
     }
     var data = {
         action: 'woo_ifactura_view_ajax_request',
-        order: order_id
+        order: order_id,
+        nonce: fyifacturaAdminVars.nonce
     }
     //console.log(data);
     jQuery.ajax({
@@ -149,7 +152,8 @@ function viewCancelInvoice() {
     }
     var data = {
         action: 'woo_ifactura_view_cancel_ajax_request',
-        order: order_id
+        order: order_id,
+        nonce: fyifacturaAdminVars.nonce
     }
     //console.log(data);
     jQuery.ajax({
@@ -179,7 +183,8 @@ function deleteInvoices()
     }
     var data = {
         action: 'woo_ifactura_delete_ajax_request',
-        order: order_id
+        order: order_id,
+        nonce: fyifacturaAdminVars.nonce
     }
     var td = jQuery(this).closest('p');
     var awaitingButton = '<a class="button tips fy-awaiting-button" data-invoice="0" href="#"></a> Borrando';

--- a/woo-ifactura/ifactura/ConectoriFactura.class.php
+++ b/woo-ifactura/ifactura/ConectoriFactura.class.php
@@ -42,7 +42,6 @@ class ConectoriFactura
      */  
     public function woo_ifactura_procesarInvoice($order_id)
     {
-        global $woocommerce;
         $totalShipping = 0.0;
         $order = wc_get_order($order_id);
         $ordenExtendida = new WCOrdenExtendida($order_id);
@@ -263,21 +262,21 @@ class ConectoriFactura
                 /** TAXES shipping **/
                 $iva_total = 0;
                 if ($it == 1) { //RESPONSABLE INSCRIPTO
-                    if ($sm['total_tax']==0 && $option_taxes == 'no') {
+                    if ($sm->get_total_tax()==0 && $option_taxes == 'no') {
 
                         $iva = 21;
                         $precio = $sm->get_total();
                         $iva_total = round((floatval($iva) * floatval($precio)) / (100 + floatval($iva)), 2);
                         $total_linea = round($precio - $iva_total, 2);
                     } else {
-                        if ($sm['total_tax']==0) {
+                        if ($sm->get_total_tax()==0) {
                             $iva = 0;
                         } else {
-                            $iva = (($sm['total_tax']*100)/$sm['total']);
+                            $iva = (($sm->get_total_tax()*100)/$sm->get_total());
                         }
                         $precio = $sm->get_total();
-                        $iva_total = round($sm['total_tax'], 2);
-                        $total_linea = round(floatval($sm['total']) + $iva_total, 2);
+                        $iva_total = round($sm->get_total_tax(), 2);
+                        $total_linea = round(floatval($sm->get_total()) + $iva_total, 2);
                     }
                 } else {
                     $iva = 0;
@@ -309,7 +308,6 @@ class ConectoriFactura
     }
     private function procesarFees($fees,&$total)
     {
-        global $woocommerce;
         $order_fees = array();
         if (is_array($fees)) {
             foreach ($fees as $k=>$v) {
@@ -339,7 +337,6 @@ class ConectoriFactura
     }
     private function procesarItems($items,$usoImpuestosWoo,$order,&$total)
     {
-        global $woocommerce;
         $it = $this->configuracion->condicionImpositiva;
         $option_taxes = get_option('woocommerce_calc_taxes');
         $Bienes = array();
@@ -942,7 +939,6 @@ class ConectoriFactura
      */
     protected function armarCliente($order_id)
     {
-        global $woocommerce;
         $ordenExtendida = new WCOrdenExtendida($order_id);
         $order = wc_get_order($order_id);
         $billing_currency   = $order->get_currency();

--- a/woo-ifactura/ifactura/ConectoriFactura.class.php
+++ b/woo-ifactura/ifactura/ConectoriFactura.class.php
@@ -250,7 +250,6 @@ class ConectoriFactura
     }
     private function procesarShipping($shipping_data,&$total)
     {
-        global $woocommerce;
         $it = $this->configuracion->condicionImpositiva;
         $option_taxes = get_option('woocommerce_calc_taxes');
         $shipping_methods = array();
@@ -267,11 +266,7 @@ class ConectoriFactura
                     if ($sm['total_tax']==0 && $option_taxes == 'no') {
 
                         $iva = 21;
-                        if ($woocommerce->version >= "3.0") {
-                            $precio = $sm->get_total();
-                        } else {
-                            $precio  = $sm['item_meta']['cost'][0];
-                        }
+                        $precio = $sm->get_total();
                         $iva_total = round((floatval($iva) * floatval($precio)) / (100 + floatval($iva)), 2);
                         $total_linea = round($precio - $iva_total, 2);
                     } else {
@@ -279,29 +274,17 @@ class ConectoriFactura
                             $iva = 0;
                         } else {
                             $iva = (($sm['total_tax']*100)/$sm['total']);
-                        }                    
-                        if ($woocommerce->version >= "3.0") {
-                            $precio = $sm->get_total();
-                        } else {
-                            $precio  = $sm['item_meta']['cost'][0];
                         }
+                        $precio = $sm->get_total();
                         $iva_total = round($sm['total_tax'], 2);
                         $total_linea = round(floatval($sm['total']) + $iva_total, 2);
                     }
                 } else {
                     $iva = 0;
-                    if ($woocommerce->version >= "3.0") {
-                        $precio = $sm->get_total();
-                    } else {
-                        $precio  = $sm['item_meta']['cost'][0];
-                    }
+                    $precio = $sm->get_total();
                     $total_linea = $precio;
                 }
-                if ($woocommerce->version >= "3.0") {
-                    $shipping_name = $sm->get_name();
-                } else {
-                    $shipping_name = $sm['name'];
-                }
+                $shipping_name = $sm->get_name();
                 if (!empty(floatval($precio))) {
                     $porcentaje_iva = $this->woo_ifactura_alicuotaiva($iva);
                     array_push(

--- a/woo-ifactura/includes/class-woo-ifactura.php
+++ b/woo-ifactura/includes/class-woo-ifactura.php
@@ -64,7 +64,7 @@ class Woo_iFactura
     {
         $this->plugin_name = 'iFactura para WooCommerce';
         
-        $this->version = '2.0.1';
+        $this->version = '2.0.2';
 
         $this->load_dependencies();
         

--- a/woo-ifactura/readme.txt
+++ b/woo-ifactura/readme.txt
@@ -1,0 +1,101 @@
+=== Woo iFactura ===
+Contributors: fedealvz
+Tags: woocommerce, factura electronica, afip, arca, argentina
+Requires at least: 6.6
+Tested up to: 7.1
+Requires PHP: 7.4
+WC requires at least: 7.3.0
+WC tested up to: 11.0.1
+Stable tag: 2.0.2
+License: GPLv3 or later
+License URI: http://www.gnu.org/licenses/gpl-3.0.html
+
+Integra WooCommerce con el servicio de factura electrónica de iFactura.com.ar (ARCA/AFIP) para tiendas argentinas.
+
+== Description ==
+
+Woo iFactura es un plugin para WooCommerce que permite emitir factura electrónica de ARCA (AFIP) mediante el servicio de [iFactura](https://www.ifactura.com.ar/).
+
+= Capacidades y funcionalidades =
+
+* Generación de factura electrónica con un solo clic
+* Impresión o descarga de la factura electrónica desde el listado de pedidos
+* Impresión o descarga de la factura electrónica desde el pedido
+* Envío automático de la factura electrónica al cliente
+
+= Requisitos =
+
+* WordPress
+* WooCommerce
+* Tener una cuenta activada en [iFactura](https://www.ifactura.com.ar/)
+
+= Consideraciones importantes =
+
+* Funciona únicamente con moneda configurada en pesos argentinos.
+* Agrega un campo "DNI" en el proceso de checkout, por lo que si ya habías hecho ajustes para obtener el documento del cliente, deberás quitarlo para evitar redundancias.
+* El campo "DNI" se usa en referencia a cualquier documento (DNI, CUIT o CUIL) y se mantiene el mismo nombre por cuestiones de retrocompatibilidad del plugin.
+
+= Consideraciones de IVA =
+
+En caso de facturar productos con IVA (21% y otros) es necesario tener configurado correctamente el apartado de impuestos en WooCommerce:
+
+* Configurar WooCommerce para que procese los valores de los productos como si no tuvieran los impuestos cargados.
+* En la sección "Tarifas Estándar" hay que configurar el impuesto IVA al porcentaje adecuado para los productos.
+* En caso de querer facturar elementos cuyo IVA sea de tipo "Exento" o "No gravado" existe una configuración en el módulo para interpretar el IVA 0% como esa condición.
+
+== Installation ==
+
+1. Subí la carpeta "woo-ifactura" al directorio de plugins de WordPress `/wp-content/plugins/`.
+2. Activá el plugin en la sección "Plugins" de WordPress.
+3. Ingresá a WooCommerce -> Ajustes -> Configuración de iFactura y completá los siguientes datos:
+    * Usuario y contraseña: tu login de iFactura (email).
+    * Punto de Venta: número de punto de venta de iFactura que vas a usar para operar.
+    * Condición Impositiva: tu condición impositiva para poder facturar.
+    * Activar "auto-envío": activalo para enviar automáticamente los comprobantes emitidos (opcional).
+    * Facturar automáticamente: permite que cuando la orden cambia su estado se genere la factura directamente sin tener que realizar ninguna acción extra (desactivado por defecto).
+    * Ignorar envíos: permite que los elementos de una orden relacionados al envío de la misma sean ignorados al momento de generar una factura (desactivado por defecto).
+    * Agrupar elementos de la venta: permite facturar directamente el total de la orden en un solo ítem de la factura. Toma automáticamente el valor de IVA de todos los productos. Esta funcionalidad no es compatible con órdenes que posean más de un IVA diferente (desactivado por defecto).
+    * Productos con IVA 0% o sin IVA: parámetro exclusivo para los Responsables Inscriptos que permite procesar los elementos que no contengan IVA a un tipo especial de IVA que puede ser "Exento" o "No gravado".
+
+= Ventas previas a la instalación del plugin =
+
+En caso de querer facturar ventas previas a la instalación de este plugin, deberás especificar los datos faltantes de facturación del cliente.
+
+Para ello, en la vista de la orden, presioná el lápiz que está al lado de la sección "Facturación" donde figuran los datos del cliente. Además, deberás completar los 2 campos personalizados que se encuentran debajo de la sección de artículos de la orden: "DNI" y "condicionimpositiva".
+
+== Usage ==
+
+En el listado de pedidos de WooCommerce vas a ver un nuevo botón de Factura en las órdenes que se encuentren en estado `Procesando`. Al presionar este botón, se enviarán los datos necesarios a iFactura para generar el comprobante correspondiente.
+
+Cada vez que ingreses al listado de pedidos, se actualizará el estado de las facturas. Si un pedido ya fue facturado, aparecerá un ícono de una factura con una flecha verde indicando que ya se puede descargar el comprobante.
+
+Si activaste "auto-envío", el envío de la factura al cliente no requiere ninguna acción, ya que iFactura la envía automáticamente al correo electrónico de tu cliente.
+
+== Frequently Asked Questions ==
+
+= ¿Funciona con otras monedas además del peso argentino? =
+
+No, el plugin funciona únicamente con la tienda configurada en pesos argentinos (ARS).
+
+= ¿Dónde reporto un problema o sugerencia? =
+
+En los [Issues de GitHub](https://github.com/fedealvz/Woo-iFactura/issues). El soporte de este plugin es comunitario; el staff de iFactura no brinda soporte técnico sobre el desarrollo o implementación de este plugin.
+
+== Changelog ==
+
+= 2.0.2 =
+* Corrección: las comprobaciones `$woocommerce->version >= "3.0"` comparaban strings, lo que las hacía evaluar `false` a partir de WooCommerce 10.0 (ej. `"11.0.1" >= "3.0"` es falso comparado como texto). Esto hacía caer el código en rutas obsoletas: `get_order_id()` accedía a la propiedad `$order->id` en desuso, y `procesarShipping()` leía `$sm['item_meta']['cost'][0]`, un formato que ya no refleja cómo WooCommerce guarda las líneas de envío — afectando el monto de envío facturado en cada comprobante emitido desde que la tienda actualizó a WooCommerce 10+. Se eliminaron las ramas obsoletas (el plugin ya requiere WooCommerce 7.3.0+).
+* Corrección: `woo_ifactura_buttons_column()` no inicializaba `$new_columns`, generando un aviso de variable indefinida.
+* Seguridad: se agregó verificación de nonce y de capacidad (`manage_woocommerce`) a los 5 endpoints AJAX de facturación/cancelación/borrado, que antes solo requerían estar autenticado como cualquier usuario de WordPress.
+* Se actualizó "WC tested up to" a 11.0.1 y se agregó "Tested up to: 7.1" (WordPress), verificado en un entorno de pruebas real con esa combinación de versiones.
+
+= 2.0.1 =
+* Corrección: se reemplazó el uso de `get_post_meta()` por la API de pedidos de WooCommerce en `armarCliente()`, ya que `get_post_meta()` falla silenciosamente cuando HPOS (High Performance Order Storage) está activo en WooCommerce 8+, dejando `billing_state` vacío y provocando que la API de iFactura rechace la factura por "El campo Provincia es requerido".
+
+= 2.0 =
+* Reescritura del plugin.
+
+== Upgrade Notice ==
+
+= 2.0.2 =
+Corrige un bug de comparación de versión que afectaba el monto de envío facturado desde WooCommerce 10+, y agrega verificación de nonce/permisos a los endpoints AJAX. Se recomienda actualizar.

--- a/woo-ifactura/woo-ifactura.php
+++ b/woo-ifactura/woo-ifactura.php
@@ -3,22 +3,23 @@
 /**
 * Plugin Name: Woo iFactura
 * Description: Woo iFactura integra WooCommerce con el servicio de factura electrónica de iFactura.com.ar
-* Version: 2.0.1
+* Version: 2.0.2
 * Author: Federico Alvarez
 * Author URI: https://github.com/fedealvz/Woo-iFactura
 * Text Domain: woo-ifactura
 * Domain Path: /languages/
 * License: GPL v3 or later
+* Tested up to: 7.1
 * WC requires at least: 7.3.0
-* WC tested up to: 9.9.5
+* WC tested up to: 11.0.1
 *
 * Copyright: © 2019-2025 Federico Alvarez
 * License: GNU General Public License v3.0
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
-* 
+*
 * @author Federico Alvarez
 * @package woo-ifactura
-* @version 2.0.1
+* @version 2.0.2
 */
 
 // If this file is called directly, abort.


### PR DESCRIPTION
## Resumen

Mientras validaba el plugin contra WordPress 7.1 / WooCommerce 11.0.1 en un entorno de pruebas que refleja una tienda real en producción, encontré un bug de compatibilidad activo (no solo un aviso en el log) y una falla de seguridad real en los endpoints AJAX. Ambos corregidos y probados en vivo.

## 1. Bug de compatibilidad: comparación de versión como string

`get_order_id()` y `procesarShipping()` protegían su camino de código moderno con `$woocommerce->version >= "3.0"` — una comparación de **strings**, no de versiones. Eso funciona por coincidencia para WC 3.x–9.x, pero se rompe apenas WooCommerce cruza la versión 10.0: PHP compara `"11.0.1"` y `"3.0"` como texto, y `"1" < "3"` léxicamente, así que la condición da `false`. En WooCommerce 11.0.1 (la versión actual), estas comprobaciones caían silenciosamente en la rama "WooCommerce viejo":

- `get_order_id()` caía al acceso obsoleto a la propiedad `$order->id`, disparando el aviso `wc_doing_it_wrong` "Order properties should not be accessed directly" en cada carga de la pantalla de pedido.
- `procesarShipping()` caía a `$sm['item_meta']['cost'][0]`, un formato heredado que ya no refleja cómo `WC_Order_Item_Shipping` guarda los datos — es decir, el precio/nombre de la línea de envío en **cada factura emitida** se calculaba desde una fuente incorrecta desde que la tienda actualizó a WooCommerce 10+, no desde el costo de envío real.

Como el plugin ya requiere WooCommerce 7.3.0+ (declarado en el header), esas ramas legacy ya eran código muerto según los propios requisitos del plugin — las eliminé directamente en lugar de solo arreglar la comparación, para que este tipo de bug no pueda volver a aparecer silenciosamente.

También corregí `woo_ifactura_buttons_column()`: `$new_columns` nunca se inicializaba antes del loop que la arma, generando un aviso de variable indefinida (y devolviendo `null` en vez del array de columnas en algunos casos).

## 2. Seguridad: sin verificación de nonce ni de capacidad en los endpoints AJAX

Los 5 endpoints AJAX de facturación (`woo_ifactura_do_ajax_request`, `woo_ifactura_do_cancel_ajax_request`, `woo_ifactura_view_ajax_request`, `woo_ifactura_view_cancel_ajax_request`, `woo_ifactura_delete_ajax_request`) no verificaban nonce ni capacidad de usuario — solo requerían estar autenticado como **cualquier** usuario de WordPress (no necesariamente un administrador o gestor de tienda) para generar, cancelar o **borrar** comprobantes de cualquier orden.

Agregué `check_ajax_referer()` + `current_user_can('manage_woocommerce')` a los 5 handlers, un nonce localizado en el JS del admin, y lo incluí en cada llamada AJAX existente.

**Verificado en vivo**: una llamada con un nonce inválido ahora devuelve `403`/`-1` (el rechazo estándar de WordPress), mientras que el flujo real desde el botón de factura sigue llegando correctamente a la lógica de negocio.

## 3. Limpieza y documentación

- Se eliminaron 4 declaraciones `global $woocommerce;` que quedaron sin uso tras remover los chequeos de versión rotos.
- Se modernizaron las últimas lecturas `$sm['total_tax']`/`$sm['total']` de `procesarShipping()` a `$sm->get_total_tax()`/`$sm->get_total()`.
- Se agregó `readme.txt` (formato estándar de plugin de WordPress, en español) con "Tested up to: 7.1" y "WC tested up to: 11.0.1" — ambos verificados en un entorno de pruebas real, no adivinados.
- Versión: 2.0.1 → 2.0.2.

## Cómo se probó

- Lint (`php -l`) limpio en todos los archivos modificados.
- Contra un entorno WordPress 7.1 + WooCommerce 11.0.1 con los mismos 21 plugins que corren en una tienda real en producción: `get_order_id()` devuelve el id correcto vía la API moderna, `procesarShipping()` devuelve el total real de la línea de envío (`$1234.56` en la prueba) en vez de caer en el camino legacy roto, `woo_ifactura_buttons_column()` maneja tanto un array vacío como uno poblado correctamente.
- Contra una orden real de producción (de forma controlada, vía `wp eval`, sin exponer datos sensibles): mismos resultados.
- Verificación de seguridad en vivo: un nonce inválido en los endpoints AJAX ahora es rechazado con `403`/`-1`; el flujo legítimo desde el botón de factura sigue funcionando sin fricción.
- Ya desplegado y verificado funcionando en una tienda real en producción (contamedemi.com.ar) sobre WordPress 7.0.4 / WooCommerce 11.0.1.

🤖 Generado con [Claude Code](https://claude.com/claude-code)